### PR TITLE
fix broken links in docs

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,11 +1,12 @@
 ---
-title: 'Introduction'
-description: 'Examples of Igbo API endpoints'
+title: "Introduction"
+description: "Examples of Igbo API endpoints"
 ---
 
 <Note>
   If you're not looking for the Igbo API reference documentation, you can
-  navigate to the [Use the Igbo API](/quickstart) section to get started.
+  navigate to the [Use the Igbo API](/igbo_api/quickstart) section to get
+  started.
 </Note>
 
 ## Welcome

--- a/guides/docker.mdx
+++ b/guides/docker.mdx
@@ -1,13 +1,13 @@
 ---
-title: 'Start with Docker'
-description: 'Start the Igbo API with Docker'
-icon: 'docker'
+title: "Start with Docker"
+description: "Start the Igbo API with Docker"
+icon: "docker"
 ---
 
 <Tip>
   This is an alternative approach to locally running the Igbo API. If you want
   to run the Igbo API on your machine, navigate to the
-  [Development](/development) section
+  [Development](/igbo_api/development) section
 </Tip>
 
 ## Step 1: Install Docker

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: 'Explore our Guides and API Reference to get the most out of the Igbo API'
+description: "Explore our Guides and API Reference to get the most out of the Igbo API"
 ---
 
 > Igbo is the principal native language of the Igbo people, an ethnic group of southeastern Nigeria, and is spoken by approx 45 million people with more than 20 different dialects.
@@ -10,10 +10,10 @@ description: 'Explore our Guides and API Reference to get the most out of the Ig
 Developers can use the Igbo API deployed, or run a local instance.
 
 <CardGroup cols={2}>
-  <Card title="Use the Igbo API" icon="rocket" href="/quickstart">
+  <Card title="Use the Igbo API" icon="rocket" href="/igbo_api/quickstart">
     Starting using the Igbo API
   </Card>
-  <Card title="Development" icon="code" href="/development">
+  <Card title="Development" icon="code" href="/igbo_api/development">
     Run the Igbo API locally on your machine
   </Card>
 </CardGroup>


### PR DESCRIPTION
Fixed broken links in intro page, docker guides, and API reference.

Resolves #8 